### PR TITLE
fix: Handle duplicate cell names

### DIFF
--- a/split.go
+++ b/split.go
@@ -94,14 +94,14 @@ func splitTemplate(dir string, r io.Reader) error {
 		for _, qn := range queryNodes {
 			// Keep track of used query names and, for any duplicates,
 			// add a numerical suffix to distinguish them.
-			var name string
+			name := qn.Name
 			if n, ok := queryNames[name]; ok {
 				name = fmt.Sprintf("%s_%d.flux", qn.Name, n)
 			} else {
 				name = fmt.Sprintf("%s.flux", qn.Name)
 			}
 			name = escapeName(name)
-			queryNames[name]++
+			queryNames[qn.Name]++
 
 			// Write out the query to file
 			filename := filepath.Join(dir, name)

--- a/split_test.go
+++ b/split_test.go
@@ -27,7 +27,6 @@ func TestSplit(t *testing.T) {
 			}
 
 			compareDirs(t, dir, filepath.Join("testdata/split", tc.Name()))
-
 		})
 	}
 }

--- a/testdata/split/dashboard-duplicate-cells/Dashboard/Test Dashboard/CPU Usage_Xy.flux
+++ b/testdata/split/dashboard-duplicate-cells/Dashboard/Test Dashboard/CPU Usage_Xy.flux
@@ -1,0 +1,5 @@
+from(bucket: "laptop")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r["_measurement"] == "cpu")
+  |> filter(fn: (r) => r["_field"] == "usage_user")
+  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)

--- a/testdata/split/dashboard-duplicate-cells/Dashboard/Test Dashboard/CPU Usage_Xy_1.flux
+++ b/testdata/split/dashboard-duplicate-cells/Dashboard/Test Dashboard/CPU Usage_Xy_1.flux
@@ -1,0 +1,5 @@
+from(bucket: "server")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r["_measurement"] == "cpu")
+  |> filter(fn: (r) => r["_field"] == "usage_user")
+  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)

--- a/testdata/split/dashboard-duplicate-cells/Dashboard/Test Dashboard/template.yml
+++ b/testdata/split/dashboard-duplicate-cells/Dashboard/Test Dashboard/template.yml
@@ -1,0 +1,78 @@
+apiVersion: influxdata.com/v2alpha1
+kind: Dashboard
+metadata:
+  name: eager-cori-839000
+spec:
+  associations:
+    - kind: Label
+      name: cool-ride-8cd001
+  charts:
+    - axes:
+        - base: '10'
+          name: x
+          scale: linear
+        - base: '10'
+          name: y
+          scale: linear
+      colors:
+        - hex: '#00A3FF'
+          id: acc6b9a5-b4b0-496a-8b6b-5f9d552e3602
+          name: Solid Blue
+          type: scale
+        - hex: '#00A3FF'
+          id: e5733dfd-4645-4de6-b4f2-1c448794f01a
+          name: Solid Blue
+          type: scale
+        - hex: '#00A3FF'
+          id: 0dbb9942-2cbf-4051-b615-63e9bd28b45a
+          name: Solid Blue
+          type: scale
+      geom: line
+      height: 4
+      hoverDimension: auto
+      kind: Xy
+      legendOpacity: 1
+      legendOrientationThreshold: 10
+      name: CPU Usage
+      position: overlaid
+      queries:
+        - query: file://CPU Usage_Xy.flux
+      width: 4
+      xCol: _time
+      yCol: _value
+    - axes:
+        - base: '10'
+          name: x
+          scale: linear
+        - base: '10'
+          name: y
+          scale: linear
+      colors:
+        - hex: '#00A3FF'
+          id: acc6b9a5-b4b0-496a-8b6b-5f9d552e3602
+          name: Solid Blue
+          type: scale
+        - hex: '#00A3FF'
+          id: e5733dfd-4645-4de6-b4f2-1c448794f01a
+          name: Solid Blue
+          type: scale
+        - hex: '#00A3FF'
+          id: 0dbb9942-2cbf-4051-b615-63e9bd28b45a
+          name: Solid Blue
+          type: scale
+      geom: line
+      height: 4
+      hoverDimension: auto
+      kind: Xy
+      legendOpacity: 1
+      legendOrientationThreshold: 10
+      name: CPU Usage
+      position: overlaid
+      queries:
+        - query: file://CPU Usage_Xy_1.flux
+      width: 4
+      xCol: _time
+      xPos: 4
+      yCol: _value
+  description: Dashboard with two cells with the same name, but different flux
+  name: Test Dashboard

--- a/testdata/united/dashboard-duplicate-cells/template.yml
+++ b/testdata/united/dashboard-duplicate-cells/template.yml
@@ -1,0 +1,88 @@
+apiVersion: influxdata.com/v2alpha1
+kind: Dashboard
+metadata:
+  name: eager-cori-839000
+spec:
+  associations:
+    - kind: Label
+      name: cool-ride-8cd001
+  charts:
+    - axes:
+        - base: '10'
+          name: x
+          scale: linear
+        - base: '10'
+          name: y
+          scale: linear
+      colors:
+        - hex: '#00A3FF'
+          id: acc6b9a5-b4b0-496a-8b6b-5f9d552e3602
+          name: Solid Blue
+          type: scale
+        - hex: '#00A3FF'
+          id: e5733dfd-4645-4de6-b4f2-1c448794f01a
+          name: Solid Blue
+          type: scale
+        - hex: '#00A3FF'
+          id: 0dbb9942-2cbf-4051-b615-63e9bd28b45a
+          name: Solid Blue
+          type: scale
+      geom: line
+      height: 4
+      hoverDimension: auto
+      kind: Xy
+      legendOpacity: 1
+      legendOrientationThreshold: 10
+      name: CPU Usage
+      position: overlaid
+      queries:
+        - query: |
+            from(bucket: "laptop")
+              |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+              |> filter(fn: (r) => r["_measurement"] == "cpu")
+              |> filter(fn: (r) => r["_field"] == "usage_user")
+              |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
+      width: 4
+      xCol: _time
+      yCol: _value
+    - axes:
+        - base: '10'
+          name: x
+          scale: linear
+        - base: '10'
+          name: y
+          scale: linear
+      colors:
+        - hex: '#00A3FF'
+          id: acc6b9a5-b4b0-496a-8b6b-5f9d552e3602
+          name: Solid Blue
+          type: scale
+        - hex: '#00A3FF'
+          id: e5733dfd-4645-4de6-b4f2-1c448794f01a
+          name: Solid Blue
+          type: scale
+        - hex: '#00A3FF'
+          id: 0dbb9942-2cbf-4051-b615-63e9bd28b45a
+          name: Solid Blue
+          type: scale
+      geom: line
+      height: 4
+      hoverDimension: auto
+      kind: Xy
+      legendOpacity: 1
+      legendOrientationThreshold: 10
+      name: CPU Usage
+      position: overlaid
+      queries:
+        - query: |
+            from(bucket: "server")
+              |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+              |> filter(fn: (r) => r["_measurement"] == "cpu")
+              |> filter(fn: (r) => r["_field"] == "usage_user")
+              |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
+      width: 4
+      xCol: _time
+      xPos: 4
+      yCol: _value
+  description: Dashboard with two cells with the same name, but different flux
+  name: Test Dashboard 


### PR DESCRIPTION
This fixes an issue where if we have duplicate cells with the same name/type, the stack-manager wasn't uniquely naming the resultant flux files. Now, as originally intended, the flux files for these cells will have an increasing numerical suffix added to them (as can be seen in the filenames generated for the test files).
